### PR TITLE
Change the domain name

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-cs.sensiolabs.org
+cs.symfony.com


### PR DESCRIPTION
As we are moving from using sensiolabs.org for Open-Source projects, I'd like to move cs.sensiolabs.org to cs.symfony.com.