### PR TITLE
Inject page title in head <title>

### DIFF
--- a/theme/layout.html
+++ b/theme/layout.html
@@ -41,7 +41,7 @@
     <meta name="Keywords" content="php, coding standards" />
     {{ metatags }}
     {%- block htmltitle %}
-      <title>{{ project }}</title>
+      <title>{% if title != project %}{{ title|striptags|e }} - {% endif %}{{ project }}</title>
     {%- endblock %}
     {{ css() }}
     {{ script() }}


### PR DESCRIPTION
Follows [this feature request](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.github.io/issues/3#issuecomment-1759835934) that i copy/paste here for readability.

## Why

The meta `<title>` tag is the same on every pages it seems, or at least on some.

Exemple: https://cs.symfony.com/doc/custom_rules.html

<img width="368" alt="Capture d’écran 2023-11-14 à 02 43 28" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.github.io/assets/1359581/20ecaf79-2c49-4669-b097-0fc19cbf72d1">


Imho, it "should" be something like: 

```
<title>Custom Rules - PhpCsFixer</title>
```

This has two (**midly**) annoying effect:
* i cannot differenciate the page when i open multiple tags (or in my history, favorite maganagement tools, etc..)
* it's sometimes harder to find those pages on Google (this one is not a good example)


<img width="433" alt="Capture d’écran 2023-11-14 à 02 46 21" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.github.io/assets/1359581/3cc25b71-dbfb-484e-9153-0a962c462427">

## What

This PR inject the page title into the <title> head tag of each page.


The "if" mainly serves to avoid "PHP Coding Standards Fixer - PHP Coding Standards Fixer" (homepage)

The "striptags" filter is necessary because a lot of pages have tags in their title Example: https://cs.symfony.com/doc/ruleSets/PhpCsFixer.html

```html
<h1>Rule set <code class="docutils literal notranslate"><span class="pre">@PhpCsFixer</span></code><a class="headerlink" href="#rule-set-phpcsfixer" title="Permalink to this headline">¶</a></h1>
```