### PR TITLE
fix: hardcode language

### DIFF
--- a/theme/layout.html
+++ b/theme/layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ language|default('en') }}">
+<html lang="en">
   <head>
     <meta charset="UTF-8">
     <meta name="description" content="{{ project }}">


### PR DESCRIPTION
appendix for

https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.github.io/pull/23/files#diff-4bb6527773da0f0939de11fedb8a03defbc2fccc023c21ad8a950d0b8233e180L39

originally lang was hardcoded.
with introduced change, the compiled HTML was `<html lang="None">`