### PR TITLE
Fix 404 assets paths

### DIFF
--- a/theme/404.html
+++ b/theme/404.html
@@ -1,7 +1,0 @@
-{%- extends "layout.html" %}
-{%- block htmltitle %}
-<title>Page not found - {{ project }}</title>
-{%- endblock %}
-{% block body %}
-  {{ body }}
-{% endblock %}

--- a/theme/layout.html
+++ b/theme/layout.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8">
     <meta name="description" content="{{ project }}">
+    {% if pagename|default == '404' %}
+      <meta name="robots" content="noindex">
+      {# 404 is pre-rendered once and later served from any directory #}
+      <base href="/">
+    {% endif %}
     {{ metatags }}
 
     <link href="{{ pathto('_static/css/reset-min.css', 1) }}" rel="stylesheet" type="text/css">


### PR DESCRIPTION
The 404 page is generated before the other pages, as a "normal page".  So...
* it does not use the 404 template
* it is rendered in a "root" context...  that's why when served as error document in a "non-root" path, the assets urls were wrong.

This PR force a `<base >` tag in the template (only for the 404 page) thus changing only this page and keeping all previous behaviours in dev.

(Fix #21 )


