### PR TITLE
deps: unpin deep dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 docutils==0.19.0
 Pygments==2.16.1
 Sphinx==5.3.0
-Jinja2<3.1 # due to `ImportError: cannot import name 'environmentfilter' from 'jinja2'`


### PR DESCRIPTION
I wonder if it's still needed to use old version of jinja2, as Sphinx was updated. hint: there is security issue in jinja2