### PR TITLE
fix: Use absolute path instead of relative

### DIFF
--- a/theme/layout.html
+++ b/theme/layout.html
@@ -52,7 +52,7 @@
           <div class="links_intro">
             <ul>
               <li>
-                <a href="./download/php-cs-fixer-v3.phar" class="download-button">
+                <a href="/download/php-cs-fixer-v3.phar" class="download-button">
                   Install now
                   <svg viewBox="0 0 24 24">
                     <path d="M13 3h-2v14.3l-4.7-4.6L5 14l5.7 5.6 1.4 1.4 1.4-1.4 5.7-5.6-1.4-1.4-4.7 4.6V3Z"/>


### PR DESCRIPTION
Fixes PHP-CS-Fixer/PHP-CS-Fixer#7951