### PR TITLE
Fix Docker usage example

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -49,6 +49,7 @@ PHP CS Fixer can be run in a Docker container.
 You can use pre-built Docker images to run ``php-cs-fixer``.
 
 .. code:: console
+
     docker run -v $(pwd):/code ghcr.io/php-cs-fixer/php-cs-fixer:${FIXER_VERSION:-3-php8.3} fix src
 
 ``$FIXER_VERSION`` used in example above is an identifier of a release you want to use, which is based on Fixer and PHP versions combined. There are different tags for each Fixer's SemVer level and PHP version with syntax ``<php-cs-fixer-version>-php<php-version>``. For example:


### PR DESCRIPTION
[Docs](https://cs.symfony.com/#run-with-docker) does not display Docker usage example.

<img width="953" height="272" alt="image" src="https://github.com/user-attachments/assets/0a40135b-426d-446e-9e4c-7453658834ba" />
